### PR TITLE
Option to specify bower path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ bower install --save-dev bower-requirejs-auto
 Add `bower-requirejs-auto/index.js` to your page, and specify options via the following attributes on its `<script>` tag:
 * `data-then`: (*required*) a main module to load after automatic configuration is complete, like RequireJS's `data-main`.
 * `data-base`: (*optional, default*: `''` ) a relative path to your "base" directory containing `bower.json` and `bower_components`.
+* `data-bower-path`: (*optional, default*: `'bower_components'`) the path of your `bower_components` directory, relative to your "base" directory.
 
 See [example](example). In summary:
 

--- a/index.js
+++ b/index.js
@@ -140,6 +140,10 @@
       for (var i = 0, m = mainItems.length; i < m; ++i) {
         mainItem = mainItems[i];
 
+        if (! mainItem.match(/\.js$/)) {
+          continue;
+        }
+
         mainItem = mainItem.replace(/\.js$/, '');
 
         var path = dir + '/' + mainItem;

--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@
 
   var opts = {
     mains: [],
-    base: ''
+    base: '',
+    bowerPath: 'bower_components'
   };
 
   var basedUrl = function (path) {
@@ -39,6 +40,12 @@
       if (base) {
         var baseVal = base.value;
         opts.base = baseVal;
+      }
+
+      var bowerPath = script.attributes['data-bower-path'];
+      if (bowerPath) {
+        var bowerPathVal = bowerPath.value;
+        opts.bowerPath = bowerPathVal;
       }
 
     }
@@ -117,7 +124,7 @@
   };
 
   var eachDep = function (dep, depName, callback) {
-    var dir = basedUrl('bower_components/' + depName);
+    var dir = basedUrl(opts.bowerPath + '/' + depName);
     get(dir + '/.bower.json', function (xhr) {
       var config = JSON.parse(xhr.responseText);
 


### PR DESCRIPTION
For some project, the bower directory may not be named `bower_components` but rather `vendor`. It might also be in a different directory specified in `bower.rc`.
To make bower-requirejs-auto work in this case, I added a config node to specify the bower path, relative to the base path. See README.md for documentation.

The second commit is strange... I took the code from the bower package of this project and it was there but not in this git.
